### PR TITLE
Fix files cleanup

### DIFF
--- a/doc/CocoapodsRepoSq.html
+++ b/doc/CocoapodsRepoSq.html
@@ -6,7 +6,7 @@
 <title>
   Module: CocoapodsRepoSq
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -87,7 +87,8 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Main namespace for cocoapods-repo-sq plugin</p>
+
+<p>Main namespace for cocoapods-repo-sq plugin</p>
 
 
   </div>
@@ -112,7 +113,8 @@
       <dt id="VERSION-constant" class="">VERSION =
         <div class="docstring">
   <div class="discussion">
-    <p>Plugin version</p>
+
+<p>Plugin version</p>
 
 
   </div>
@@ -122,7 +124,7 @@
 
 </div>
       </dt>
-      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>0.0.1</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
+      <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>0.0.2</span><span class='tstring_end'>&#39;</span></span><span class='period'>.</span><span class='id identifier rubyid_freeze'>freeze</span></pre></dd>
 
   </dl>
 
@@ -137,9 +139,9 @@
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:22 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/CocoapodsRepoSq/Downloader.html
+++ b/doc/CocoapodsRepoSq/Downloader.html
@@ -6,7 +6,7 @@
 <title>
   Class: CocoapodsRepoSq::Downloader
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -103,7 +103,8 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Implemenents a <a href="https://github.com/CocoaPods/cocoapods-downloader" target="_parent" title="downloader strategy">downloader strategy</a> to support downloading files from a Square SDK
+
+<p>Implemenents a <a href="https://github.com/CocoaPods/cocoapods-downloader" target="_parent" title="downloader strategy">downloader strategy</a> to support downloading files from a Square SDK
 repository server over the HTTPS protocol with
 <a href="https://tools.ietf.org/html/rfc7617" target="_parent" title="Basic HTTP Authentication RFC7617">Basic HTTP Authentication RFC7617</a></p>
 
@@ -155,7 +156,8 @@ repository server over the HTTPS protocol with
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Options accepted by this dowmloader strategy.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Options accepted by this dowmloader strategy.</p>
 </div></span>
 
 </li>
@@ -187,7 +189,8 @@ repository server over the HTTPS protocol with
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Square SDK repository to be used by this downloader.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Square SDK repository to be used by this downloader.</p>
 </div></span>
 
 </li>
@@ -214,11 +217,13 @@ repository server over the HTTPS protocol with
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Options accepted by this dowmloader strategy.
-The base class already supports <code>:flatten</code>, <code>:type</code>, <code>:sha256</code>, <code>:sha1</code>.
-<span class='object_link'><a href="" title="CocoapodsRepoSq::Downloader (class)">CocoapodsRepoSq::Downloader</a></span> supports passing a <code>:repository</code> option to indicate which
-Square SDK repository to download files from. If none is provided, it
-will try to use the current repository. See <span class='object_link'><a href="Repository.html#current-class_method" title="CocoapodsRepoSq::Repository.current (method)">Repository.current</a></span></p>
+
+<p>Options accepted by this dowmloader strategy. The base class already
+supports <code>:flatten</code>, <code>:type</code>, <code>:sha256</code>,
+<code>:sha1</code>. <span class='object_link'><a href="" title="CocoapodsRepoSq::Downloader (class)">CocoapodsRepoSq::Downloader</a></span> supports passing a
+<code>:repository</code> option to indicate which Square SDK repository to
+download files from. If none is provided, it will try to use the current
+repository. See <span class='object_link'><a href="Repository.html#current-class_method" title="CocoapodsRepoSq::Repository.current (method)">Repository.current</a></span></p>
 
 
   </div>
@@ -236,7 +241,8 @@ will try to use the current repository. See <span class='object_link'><a href="R
 
 
         &mdash;
-        <div class='inline'><p>a list of accepted options</p>
+        <div class='inline'>
+<p>a list of accepted options</p>
 </div>
 
     </li>
@@ -281,9 +287,10 @@ will try to use the current repository. See <span class='object_link'><a href="R
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Square SDK repository to be used by this downloader.
-It can be passed as an option when initializing this class or also taken
-from the current repository. See <span class='object_link'><a href="Repository.html#current-class_method" title="CocoapodsRepoSq::Repository.current (method)">Repository.current</a></span></p>
+
+<p>Square SDK repository to be used by this downloader. It can be passed as an
+option when initializing this class or also taken from the current
+repository. See <span class='object_link'><a href="Repository.html#current-class_method" title="CocoapodsRepoSq::Repository.current (method)">Repository.current</a></span></p>
 
 
   </div>
@@ -301,7 +308,8 @@ from the current repository. See <span class='object_link'><a href="Repository.h
 
 
         &mdash;
-        <div class='inline'><p>a Square SDK repository</p>
+        <div class='inline'>
+<p>a Square SDK repository</p>
 </div>
 
     </li>
@@ -334,9 +342,9 @@ from the current repository. See <span class='object_link'><a href="Repository.h
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:23 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/CocoapodsRepoSq/Downloader/Extensions.html
+++ b/doc/CocoapodsRepoSq/Downloader/Extensions.html
@@ -6,7 +6,7 @@
 <title>
   Module: CocoapodsRepoSq::Downloader::Extensions
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -85,8 +85,10 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Helper module used to override the Pod::Downloader::downloader_class_by_key method to
-include a <code>:square</code> key pointing to <span class='object_link'><a href="../Downloader.html" title="CocoapodsRepoSq::Downloader (class)">CocoapodsRepoSq::Downloader</a></span>. This allows square to be
+
+<p>Helper module used to override the
+Pod::Downloader::downloader_class_by_key method to include a
+<code>:square</code> key pointing to <span class='object_link'><a href="../Downloader.html" title="CocoapodsRepoSq::Downloader (class)">CocoapodsRepoSq::Downloader</a></span>. This allows square to be
 defined as the protocol for downloading Pods on the
 <a href="https://guides.cocoapods.org/syntax/podspec.html#source" target="_parent" title="podfile source setting">podfile source setting</a></p>
 
@@ -128,7 +130,9 @@ defined as the protocol for downloading Pods on the
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Map of downloaded classes supported by Cocoapods available to the <a href="https://guides.cocoapods.org/syntax/podspec.html#source" target="_parent" title="podfile source setting">podfile source setting</a>.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Map of downloaded classes supported by Cocoapods available to the
+<a href="https://guides.cocoapods.org/syntax/podspec.html#source" target="_parent" title="podfile source setting">podfile source setting</a>.</p>
 </div></span>
 
 </li>
@@ -154,7 +158,8 @@ defined as the protocol for downloading Pods on the
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Map of downloaded classes supported by Cocoapods available to the
+
+<p>Map of downloaded classes supported by Cocoapods available to the
 <a href="https://guides.cocoapods.org/syntax/podspec.html#source" target="_parent" title="podfile source setting">podfile source setting</a>. Square is included to add support for Square SDK repository
 hosted podspecs and pods.</p>
 
@@ -174,9 +179,10 @@ hosted podspecs and pods.</p>
 
 
         &mdash;
-        <div class='inline'><p>a map where the key is a symbol used in the podspec source
-setting such as <code>:http</code>, <code>:git</code>, <code>:square</code> and the class is the one
-responsible for implementing a particular download strategy</p>
+        <div class='inline'>
+<p>a map where the key is a symbol used in the podspec source setting such as
+<code>:http</code>, <code>:git</code>, <code>:square</code> and the class
+is the one responsible for implementing a particular download strategy</p>
 </div>
 
     </li>
@@ -209,9 +215,9 @@ responsible for implementing a particular download strategy</p>
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:22 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/CocoapodsRepoSq/Repository.html
+++ b/doc/CocoapodsRepoSq/Repository.html
@@ -6,7 +6,7 @@
 <title>
   Class: CocoapodsRepoSq::Repository
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -101,7 +101,8 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Class that represents the credentials needed to access a Square SDK
+
+<p>Class that represents the credentials needed to access a Square SDK
 repository of <a href="https://guides.cocoapods.org/syntax/podspec.html" target="_parent" title="podspecs">podspecs</a>
 for a given Square Application. Responsible for downloading a copy of the
 repository from Square servers and cache it on the local filesystem.</p>
@@ -139,7 +140,9 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Square SDK repository set by the plugin initialization on the <a href="https://guides.cocoapods.org/syntax/podfile.html#plugin" target="_parent" title="Podfile">Podfile</a>.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Square SDK repository set by the plugin initialization on the
+<a href="https://guides.cocoapods.org/syntax/podfile.html#plugin" target="_parent" title="Podfile">Podfile</a>.</p>
 </div></span>
 
 </li>
@@ -172,7 +175,9 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Nickname under which a Square SDK repository was registered on the <span class='object_link'><a href="RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">RepositoryStore</a></span>.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Nickname under which a Square SDK repository was registered on the
+<span class='object_link'><a href="RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">RepositoryStore</a></span>.</p>
 </div></span>
 
 </li>
@@ -200,7 +205,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Server password used to access a specific Square SDK repository.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Server password used to access a specific Square SDK repository.</p>
 </div></span>
 
 </li>
@@ -228,7 +234,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Local filesystem path where this repository cache of podspecs is stored.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Local filesystem path where this repository cache of podspecs is stored.</p>
 </div></span>
 
 </li>
@@ -256,7 +263,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Square SDK repositories server url.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Square SDK repositories server url.</p>
 </div></span>
 
 </li>
@@ -284,7 +292,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Server user name used to access a specific Square SDK repository.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Server user name used to access a specific Square SDK repository.</p>
 </div></span>
 
 </li>
@@ -322,7 +331,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>A new instance of Repository.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>A new instance of Repository.</p>
 </div></span>
 
 </li>
@@ -345,7 +355,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Updates the local copy of the podspecs from the Square SDK repository.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Updates the local copy of the podspecs from the Square SDK repository.</p>
 </div></span>
 
 </li>
@@ -368,7 +379,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns a new instance of Repository</p>
+
+<p>Returns a new instance of Repository</p>
 
 
   </div>
@@ -387,7 +399,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
         &mdash;
-        <div class='inline'><p>nickname under which a Square SDK repository was registered on the
+        <div class='inline'>
+<p>nickname under which a Square SDK repository was registered on the
 <span class='object_link'><a href="RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
 </div>
 
@@ -403,7 +416,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
         &mdash;
-        <div class='inline'><p>server user name used to access a specific Square SDK repository.</p>
+        <div class='inline'>
+<p>server user name used to access a specific Square SDK repository.</p>
 </div>
 
     </li>
@@ -418,7 +432,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
         &mdash;
-        <div class='inline'><p>server password used to access a specific Square SDK repository.</p>
+        <div class='inline'>
+<p>server password used to access a specific Square SDK repository.</p>
 </div>
 
     </li>
@@ -433,7 +448,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
         &mdash;
-        <div class='inline'><p>Square SDK repositories server url.</p>
+        <div class='inline'>
+<p>Square SDK repositories server url.</p>
 </div>
 
     </li>
@@ -448,7 +464,8 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 
         &mdash;
-        <div class='inline'><p>local filesystem path where this repository cache of podspecs is stored.</p>
+        <div class='inline'>
+<p>local filesystem path where this repository cache of podspecs is stored.</p>
 </div>
 
     </li>
@@ -503,13 +520,14 @@ repository from Square servers and cache it on the local filesystem.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Square SDK repository set by the plugin initialization on the
-<a href="https://guides.cocoapods.org/syntax/podfile.html#plugin" target="_parent" title="Podfile">Podfile</a>.
-This setting is used by the <span class='object_link'><a href="Downloader.html" title="CocoapodsRepoSq::Downloader (class)">Downloader</a></span> class to know which repository
-to download files from in the context of a <code>pod install</code> or <code>pod update</code>
-command call. When a podspec indicates a Square source it does not have
-a Square SDK repository reference to provide to the Downloader class so
-this global setting is used instead.</p>
+
+<p>Square SDK repository set by the plugin initialization on the
+<a href="https://guides.cocoapods.org/syntax/podfile.html#plugin" target="_parent" title="Podfile">Podfile</a>. This
+setting is used by the <span class='object_link'><a href="Downloader.html" title="CocoapodsRepoSq::Downloader (class)">Downloader</a></span> class to know which repository to
+download files from in the context of a <code>pod install</code> or
+<code>pod update</code> command call. When a podspec indicates a Square
+source it does not have a Square SDK repository reference to provide to the
+Downloader class so this global setting is used instead.</p>
 
 
   </div>
@@ -527,7 +545,8 @@ this global setting is used instead.</p>
 
 
         &mdash;
-        <div class='inline'><p>current Square SDK repository</p>
+        <div class='inline'>
+<p>current Square SDK repository</p>
 </div>
 
     </li>
@@ -573,7 +592,8 @@ this global setting is used instead.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns nickname under which a Square SDK repository was registered on the
+
+<p>Returns nickname under which a Square SDK repository was registered on the
 <span class='object_link'><a href="RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
 
 
@@ -592,7 +612,8 @@ this global setting is used instead.</p>
 
 
         &mdash;
-        <div class='inline'><p>nickname under which a Square SDK repository was registered on the
+        <div class='inline'>
+<p>nickname under which a Square SDK repository was registered on the
 <span class='object_link'><a href="RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
 </div>
 
@@ -634,7 +655,8 @@ this global setting is used instead.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns server password used to access a specific Square SDK repository.</p>
+
+<p>Returns server password used to access a specific Square SDK repository.</p>
 
 
   </div>
@@ -652,7 +674,8 @@ this global setting is used instead.</p>
 
 
         &mdash;
-        <div class='inline'><p>server password used to access a specific Square SDK repository.</p>
+        <div class='inline'>
+<p>server password used to access a specific Square SDK repository.</p>
 </div>
 
     </li>
@@ -693,7 +716,9 @@ this global setting is used instead.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns local filesystem path where this repository cache of podspecs is stored.</p>
+
+<p>Returns local filesystem path where this repository cache of podspecs is
+stored.</p>
 
 
   </div>
@@ -711,7 +736,8 @@ this global setting is used instead.</p>
 
 
         &mdash;
-        <div class='inline'><p>local filesystem path where this repository cache of podspecs is stored.</p>
+        <div class='inline'>
+<p>local filesystem path where this repository cache of podspecs is stored.</p>
 </div>
 
     </li>
@@ -752,7 +778,8 @@ this global setting is used instead.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns Square SDK repositories server url.</p>
+
+<p>Returns Square SDK repositories server url.</p>
 
 
   </div>
@@ -770,7 +797,8 @@ this global setting is used instead.</p>
 
 
         &mdash;
-        <div class='inline'><p>Square SDK repositories server url.</p>
+        <div class='inline'>
+<p>Square SDK repositories server url.</p>
 </div>
 
     </li>
@@ -811,7 +839,8 @@ this global setting is used instead.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns server user name used to access a specific Square SDK repository.</p>
+
+<p>Returns server user name used to access a specific Square SDK repository.</p>
 
 
   </div>
@@ -829,7 +858,8 @@ this global setting is used instead.</p>
 
 
         &mdash;
-        <div class='inline'><p>server user name used to access a specific Square SDK repository.</p>
+        <div class='inline'>
+<p>server user name used to access a specific Square SDK repository.</p>
 </div>
 
     </li>
@@ -875,7 +905,8 @@ this global setting is used instead.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Updates the local copy of the podspecs from the Square SDK repository</p>
+
+<p>Updates the local copy of the podspecs from the Square SDK repository</p>
 
 
   </div>
@@ -901,7 +932,8 @@ this global setting is used instead.</p>
 97
 98
 99
-100</pre>
+100
+101</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/cocoapods_repo_sq/repository.rb', line 88</span>
@@ -914,8 +946,9 @@ this global setting is used instead.</p>
 
   <span class='comment'># perform cleanup
 </span>  <span class='id identifier rubyid_specs_path'>specs_path</span> <span class='op'>=</span> <span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_join'>join</span><span class='lparen'>(</span><span class='ivar'>@path</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Specs</span><span class='tstring_end'>&#39;</span></span><span class='rparen'>)</span>
-  <span class='const'>FileUtils</span><span class='period'>.</span><span class='id identifier rubyid_rm'>rm</span><span class='lparen'>(</span><span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_join'>join</span><span class='lparen'>(</span><span class='id identifier rubyid_new_specs_path'>new_specs_path</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>file.zip</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span><span class='rparen'>)</span>
-  <span class='const'>FileUtils</span><span class='period'>.</span><span class='id identifier rubyid_rm_rf'>rm_rf</span><span class='lparen'>(</span><span class='id identifier rubyid_specs_path'>specs_path</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_new_specs_file'>new_specs_file</span> <span class='op'>=</span> <span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_join'>join</span><span class='lparen'>(</span><span class='id identifier rubyid_new_specs_path'>new_specs_path</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>file.zip</span><span class='tstring_end'>&quot;</span></span><span class='rparen'>)</span>
+  <span class='const'>FileUtils</span><span class='period'>.</span><span class='id identifier rubyid_rm'>rm</span><span class='lparen'>(</span><span class='id identifier rubyid_new_specs_file'>new_specs_file</span><span class='rparen'>)</span> <span class='kw'>if</span> <span class='const'>File</span><span class='period'>.</span><span class='id identifier rubyid_exists?'>exists?</span><span class='lparen'>(</span><span class='id identifier rubyid_new_specs_file'>new_specs_file</span><span class='rparen'>)</span>
+  <span class='const'>FileUtils</span><span class='period'>.</span><span class='id identifier rubyid_rm_rf'>rm_rf</span><span class='lparen'>(</span><span class='id identifier rubyid_specs_path'>specs_path</span><span class='rparen'>)</span> <span class='kw'>if</span> <span class='const'>Dir</span><span class='period'>.</span><span class='id identifier rubyid_exists?'>exists?</span><span class='lparen'>(</span><span class='id identifier rubyid_specs_path'>specs_path</span><span class='rparen'>)</span>
   <span class='const'>FileUtils</span><span class='period'>.</span><span class='id identifier rubyid_mv'>mv</span><span class='lparen'>(</span><span class='id identifier rubyid_new_specs_path'>new_specs_path</span><span class='comma'>,</span> <span class='id identifier rubyid_specs_path'>specs_path</span><span class='rparen'>)</span>
   <span class='kw'>nil</span>
 <span class='kw'>end</span></pre>
@@ -929,9 +962,9 @@ this global setting is used instead.</p>
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:23 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/CocoapodsRepoSq/RepositoryStore.html
+++ b/doc/CocoapodsRepoSq/RepositoryStore.html
@@ -6,7 +6,7 @@
 <title>
   Class: CocoapodsRepoSq::RepositoryStore
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -101,9 +101,10 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Class responsible for managing user configured Square SDK repositories.
+
+<p>Class responsible for managing user configured Square SDK repositories.
 Repository settings and a local copy of the podspecs are stored on the
-filesystem inside Cocoapods’ home directory.</p>
+filesystem inside Cocoapods&#39; home directory.</p>
 
 
   </div>
@@ -143,7 +144,8 @@ filesystem inside Cocoapods’ home directory.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Default store located in Cocoapods’s home directory.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Default store located in Cocoapods&#39;s home directory.</p>
 </div></span>
 
 </li>
@@ -175,7 +177,8 @@ filesystem inside Cocoapods’ home directory.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Indicates if a Square SDK repository has been added to the store.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Indicates if a Square SDK repository has been added to the store.</p>
 </div></span>
 
 </li>
@@ -198,7 +201,9 @@ filesystem inside Cocoapods’ home directory.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Returns a <span class='object_link'><a href="Repository.html" title="CocoapodsRepoSq::Repository (class)">Repository</a></span> instance if a Square SDK repository exists in the store with the given name.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Returns a <span class='object_link'><a href="Repository.html" title="CocoapodsRepoSq::Repository (class)">Repository</a></span> instance if a Square SDK repository exists in the
+store with the given name.</p>
 </div></span>
 
 </li>
@@ -223,7 +228,8 @@ filesystem inside Cocoapods’ home directory.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>A new instance of RepositoryStore.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>A new instance of RepositoryStore.</p>
 </div></span>
 
 </li>
@@ -246,7 +252,9 @@ filesystem inside Cocoapods’ home directory.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Returns all repositories currently configured in the store as a list of <span class='object_link'><a href="Repository.html" title="CocoapodsRepoSq::Repository (class)">Repository</a></span> objects.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Returns all repositories currently configured in the store as a list of
+<span class='object_link'><a href="Repository.html" title="CocoapodsRepoSq::Repository (class)">Repository</a></span> objects.</p>
 </div></span>
 
 </li>
@@ -269,7 +277,8 @@ filesystem inside Cocoapods’ home directory.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Registers a Square SDK repository on the local store.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Registers a Square SDK repository on the local store.</p>
 </div></span>
 
 </li>
@@ -292,7 +301,8 @@ filesystem inside Cocoapods’ home directory.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Removes a Square SDK repository from the local store.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Removes a Square SDK repository from the local store.</p>
 </div></span>
 
 </li>
@@ -315,7 +325,8 @@ filesystem inside Cocoapods’ home directory.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns a new instance of RepositoryStore</p>
+
+<p>Returns a new instance of RepositoryStore</p>
 
 
   </div>
@@ -336,8 +347,9 @@ filesystem inside Cocoapods’ home directory.</p>
 
 
         &mdash;
-        <div class='inline'><p>the path where all Square SDK repositories will be stored. If no path
-is provided a default <code>$COCOAPODS_HOME/repo-sq</code> will be used</p>
+        <div class='inline'>
+<p>the path where all Square SDK repositories will be stored. If no path is
+provided a default <code>$COCOAPODS_HOME/repo-sq</code> will be used</p>
 </div>
 
     </li>
@@ -386,9 +398,10 @@ is provided a default <code>$COCOAPODS_HOME/repo-sq</code> will be used</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Default store located in Cocoapods’s home directory.
-Used by the plugin to look for registered repositories or by the <code>repo-sq</code>
-commands to manage registered repositories.</p>
+
+<p>Default store located in Cocoapods&#39;s home directory. Used by the plugin
+to look for registered repositories or by the <code>repo-sq</code> commands
+to manage registered repositories.</p>
 
 
   </div>
@@ -406,7 +419,8 @@ commands to manage registered repositories.</p>
 
 
         &mdash;
-        <div class='inline'><p>the default RepositoryStore</p>
+        <div class='inline'>
+<p>the default RepositoryStore</p>
 </div>
 
     </li>
@@ -451,7 +465,8 @@ commands to manage registered repositories.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Indicates if a Square SDK repository has been added to the store</p>
+
+<p>Indicates if a Square SDK repository has been added to the store</p>
 
 
   </div>
@@ -470,7 +485,8 @@ commands to manage registered repositories.</p>
 
 
         &mdash;
-        <div class='inline'><p>the Square SDK repository name to look for</p>
+        <div class='inline'>
+<p>the Square SDK repository name to look for</p>
 </div>
 
     </li>
@@ -488,8 +504,9 @@ commands to manage registered repositories.</p>
 
 
         &mdash;
-        <div class='inline'><p><code>true</code> if the targeted Square SDK repository is configured in this
-repository store, otherwise <code>false</code>.</p>
+        <div class='inline'>
+<p><code>true</code> if the targeted Square SDK repository is configured in
+this repository store, otherwise <code>false</code>.</p>
 </div>
 
     </li>
@@ -528,7 +545,8 @@ repository store, otherwise <code>false</code>.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns a <span class='object_link'><a href="Repository.html" title="CocoapodsRepoSq::Repository (class)">CocoapodsRepoSq::Repository</a></span> instance if a Square SDK repository exists in the
+
+<p>Returns a <span class='object_link'><a href="Repository.html" title="CocoapodsRepoSq::Repository (class)">CocoapodsRepoSq::Repository</a></span> instance if a Square SDK repository exists in the
 store with the given name</p>
 
 
@@ -548,7 +566,8 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p>the Square SDK repository name to look for</p>
+        <div class='inline'>
+<p>the Square SDK repository name to look for</p>
 </div>
 
     </li>
@@ -566,7 +585,8 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p>a Square SDK repository</p>
+        <div class='inline'>
+<p>a Square SDK repository</p>
 </div>
 
     </li>
@@ -623,7 +643,8 @@ store with the given name</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns all repositories currently configured in the store as a list of
+
+<p>Returns all repositories currently configured in the store as a list of
 <span class='object_link'><a href="Repository.html" title="CocoapodsRepoSq::Repository (class)">CocoapodsRepoSq::Repository</a></span> objects</p>
 
 
@@ -642,7 +663,8 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p>the list of all Square SDK repositories</p>
+        <div class='inline'>
+<p>the list of all Square SDK repositories</p>
 </div>
 
     </li>
@@ -687,7 +709,8 @@ store with the given name</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Registers a Square SDK repository on the local store</p>
+
+<p>Registers a Square SDK repository on the local store</p>
 
 
   </div>
@@ -706,7 +729,8 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p>the Square SDK repository name.</p>
+        <div class='inline'>
+<p>the Square SDK repository name.</p>
 </div>
 
     </li>
@@ -721,7 +745,8 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p>the Square SDK repository username.</p>
+        <div class='inline'>
+<p>the Square SDK repository username.</p>
 </div>
 
     </li>
@@ -736,7 +761,8 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p>the Square SDK repository password.</p>
+        <div class='inline'>
+<p>the Square SDK repository password.</p>
 </div>
 
     </li>
@@ -751,7 +777,8 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p>the Square SDK repositories server URL.</p>
+        <div class='inline'>
+<p>the Square SDK repositories server URL.</p>
 </div>
 
     </li>
@@ -769,7 +796,8 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p>a Square SDK repository</p>
+        <div class='inline'>
+<p>a Square SDK repository</p>
 </div>
 
     </li>
@@ -786,7 +814,8 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p>if the repository has already been configured</p>
+        <div class='inline'>
+<p>if the repository has already been configured</p>
 </div>
 
     </li>
@@ -847,7 +876,8 @@ store with the given name</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Removes a Square SDK repository from the local store</p>
+
+<p>Removes a Square SDK repository from the local store</p>
 
 
   </div>
@@ -866,7 +896,8 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p>the name of the Square SDK Repository to be removed.</p>
+        <div class='inline'>
+<p>the name of the Square SDK Repository to be removed.</p>
 </div>
 
     </li>
@@ -884,8 +915,9 @@ store with the given name</p>
 
 
         &mdash;
-        <div class='inline'><p><code>true</code> if the targeted Square SDK repository was removed from the store,
-otherwise <code>false</code>.</p>
+        <div class='inline'>
+<p><code>true</code> if the targeted Square SDK repository was removed from
+the store, otherwise <code>false</code>.</p>
 </div>
 
     </li>
@@ -920,9 +952,9 @@ otherwise <code>false</code>.</p>
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:23 2018 by
+  Generated on Fri Jun  1 09:24:34 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/CocoapodsRepoSq/Source.html
+++ b/doc/CocoapodsRepoSq/Source.html
@@ -6,7 +6,7 @@
 <title>
   Class: CocoapodsRepoSq::Source
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -103,7 +103,8 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Class responsible of managing a collection of podspecs and pods hosted at a
+
+<p>Class responsible of managing a collection of podspecs and pods hosted at a
 Square SDK repository. Files are accessed via HTTPS with
 <a href="https://tools.ietf.org/html/rfc7617" target="_parent" title="Basic HTTP Authentication RFC7617">Basic HTTP Authentication RFC7617</a></p>
 
@@ -142,7 +143,8 @@ Square SDK repository. Files are accessed via HTTPS with
 
 
 
-    <span class="summary_desc"><div class='inline'><p>An object representing a Square SDK repository.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>An object representing a Square SDK repository.</p>
 </div></span>
 
 </li>
@@ -180,7 +182,8 @@ Square SDK repository. Files are accessed via HTTPS with
 
 
 
-    <span class="summary_desc"><div class='inline'><p>A new instance of Source.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>A new instance of Source.</p>
 </div></span>
 
 </li>
@@ -204,7 +207,8 @@ Square SDK repository. Files are accessed via HTTPS with
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns a new instance of Source</p>
+
+<p>Returns a new instance of Source</p>
 
 
   </div>
@@ -223,8 +227,9 @@ Square SDK repository. Files are accessed via HTTPS with
 
 
         &mdash;
-        <div class='inline'><p>an object representing a Square SDK repository where this source will
-get podspecs from.</p>
+        <div class='inline'>
+<p>an object representing a Square SDK repository where this source will get
+podspecs from.</p>
 </div>
 
     </li>
@@ -273,7 +278,8 @@ get podspecs from.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns an object representing a Square SDK repository</p>
+
+<p>Returns an object representing a Square SDK repository</p>
 
 
   </div>
@@ -291,7 +297,8 @@ get podspecs from.</p>
 
 
         &mdash;
-        <div class='inline'><p>an object representing a Square SDK repository</p>
+        <div class='inline'>
+<p>an object representing a Square SDK repository</p>
 </div>
 
     </li>
@@ -325,9 +332,9 @@ get podspecs from.</p>
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:23 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/Pod.html
+++ b/doc/Pod.html
@@ -6,7 +6,7 @@
 <title>
   Module: Pod
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -87,23 +87,24 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>This source file is part of the cocoapods-repo-sq plugin under the Apache 2.0
-license:</p>
+
+<p>This source file is part of the cocoapods-repo-sq plugin under the Apache
+2.0 license:</p>
 
 <p>Copyright 2018 Square Inc.</p>
 
-<p>Licensed under the Apache License, Version 2.0 (the “License”);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at</p>
+<p>Licensed under the Apache License, Version 2.0 (the “License”);  you may
+not use this file except in compliance with the License.  You may obtain a
+copy of the License at</p>
 
 <pre class="code ruby"><code class="ruby">   <span class='id identifier rubyid_http'>http</span><span class='symbol'>:/</span><span class='op'>/</span><span class='id identifier rubyid_www'>www</span><span class='period'>.</span><span class='id identifier rubyid_apache'>apache</span><span class='period'>.</span><span class='id identifier rubyid_org'>org</span><span class='op'>/</span><span class='id identifier rubyid_licenses'>licenses</span><span class='op'>/</span><span class='const'>LICENSE</span><span class='op'>-</span><span class='float'>2.0</span>
 </code></pre>
 
 <p>Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an “AS IS” BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.</p>
+distributed under the License is distributed on an “AS IS” BASIS,  WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and  limitations
+under the License.</p>
 
 <p>=============================================================================</p>
 
@@ -135,9 +136,9 @@ license:</p>
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:22 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/Pod/Command.html
+++ b/doc/Pod/Command.html
@@ -6,7 +6,7 @@
 <title>
   Class: Pod::Command
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -127,9 +127,9 @@
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:22 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/Pod/Command/RepoSq.html
+++ b/doc/Pod/Command/RepoSq.html
@@ -6,7 +6,7 @@
 <title>
   Class: Pod::Command::RepoSq
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -105,7 +105,9 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Subclass of Pod::Command to provide <code>pod repo-sq</code> command to manage Square SDK repositories</p>
+
+<p>Subclass of Pod::Command to provide <code>pod repo-sq</code> command to
+manage Square SDK repositories</p>
 
 
   </div>
@@ -145,9 +147,9 @@
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:23 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/Pod/Command/RepoSq/Add.html
+++ b/doc/Pod/Command/RepoSq/Add.html
@@ -6,7 +6,7 @@
 <title>
   Class: Pod::Command::RepoSq::Add
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -105,9 +105,10 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Subclass of <span class='object_link'><a href="../RepoSq.html" title="Pod::Command::RepoSq (class)">Pod::Command::RepoSq</a></span>
-Provides support for the <code>pod repo-sq add</code> which adds a Square SDK
-repository to the user’s cocoapods local repositories store.</p>
+
+<p>Subclass of <span class='object_link'><a href="../RepoSq.html" title="Pod::Command::RepoSq (class)">Pod::Command::RepoSq</a></span> Provides support for the <code>pod repo-sq add</code>
+which adds a Square SDK repository to the user&#39;s cocoapods local
+repositories store.</p>
 
 
   </div>
@@ -122,9 +123,10 @@ repository to the user’s cocoapods local repositories store.</p>
       <dt id="DEFAULT_URL-constant" class="">DEFAULT_URL =
         <div class="docstring">
   <div class="discussion">
-    <p>Default Square SDK repositories server URL.
-This URL can be customized by providing a fourth undocumented
-parameter to this command but not intended for public use.</p>
+
+<p>Default Square SDK repositories server URL. This URL can be customized by
+providing a fourth undocumented parameter to this command but not intended
+for public use.</p>
 
 
   </div>
@@ -142,7 +144,8 @@ parameter to this command but not intended for public use.</p>
 
 
         &mdash;
-        <div class='inline'><p>default Square SDK repositories server URL.</p>
+        <div class='inline'>
+<p>default Square SDK repositories server URL.</p>
 </div>
 
     </li>
@@ -188,7 +191,8 @@ parameter to this command but not intended for public use.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>A new instance of Add.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>A new instance of Add.</p>
 </div></span>
 
 </li>
@@ -211,7 +215,9 @@ parameter to this command but not intended for public use.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Registers a Square SDK repository on the current user <span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Registers a Square SDK repository on the current user
+<span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
 </div></span>
 
 </li>
@@ -234,7 +240,9 @@ parameter to this command but not intended for public use.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Validates that all required arguments are present: <code>NAME</code>, <code>USERNAME</code> and <code>PASSWORD</code>.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Validates that all required arguments are present: <code>NAME</code>,
+<code>USERNAME</code> and <code>PASSWORD</code>.</p>
 </div></span>
 
 </li>
@@ -269,7 +277,8 @@ parameter to this command but not intended for public use.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns a new instance of Add</p>
+
+<p>Returns a new instance of Add</p>
 
 
   </div>
@@ -324,10 +333,10 @@ parameter to this command but not intended for public use.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Registers a Square SDK repository on the current user
-<span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.
-It checks that the user name and password are valid and that the
-repository exists on the Square server.</p>
+
+<p>Registers a Square SDK repository on the current user
+<span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>. It checks that the user name and
+password are valid and that the repository exists on the Square server.</p>
 
 
   </div>
@@ -387,8 +396,9 @@ repository exists on the Square server.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Validates that all required arguments are present: <code>NAME</code>, <code>USERNAME</code>
-and <code>PASSWORD</code></p>
+
+<p>Validates that all required arguments are present: <code>NAME</code>,
+<code>USERNAME</code> and <code>PASSWORD</code></p>
 
 
   </div>
@@ -428,9 +438,9 @@ and <code>PASSWORD</code></p>
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:23 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/Pod/Command/RepoSq/List.html
+++ b/doc/Pod/Command/RepoSq/List.html
@@ -6,7 +6,7 @@
 <title>
   Class: Pod::Command::RepoSq::List
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -105,10 +105,10 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Subclass of <span class='object_link'><a href="../RepoSq.html" title="Pod::Command::RepoSq (class)">Pod::Command::RepoSq</a></span>
-Provides support for the <code>pod repo-sq list</code> command, which lists the
-Square SDK repositories currently registered on the user’s cocoapods
-local repositories store.</p>
+
+<p>Subclass of <span class='object_link'><a href="../RepoSq.html" title="Pod::Command::RepoSq (class)">Pod::Command::RepoSq</a></span> Provides support for the <code>pod repo-sq list</code>
+command, which lists the Square SDK repositories currently registered on
+the user&#39;s cocoapods local repositories store.</p>
 
 
   </div>
@@ -148,7 +148,9 @@ local repositories store.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Lists all Square SDK repositories registered on the current user <span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Lists all Square SDK repositories registered on the current user
+<span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
 </div></span>
 
 </li>
@@ -186,7 +188,8 @@ local repositories store.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Lists all Square SDK repositories registered on the current user
+
+<p>Lists all Square SDK repositories registered on the current user
 <span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
 
 
@@ -243,9 +246,9 @@ local repositories store.</p>
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:23 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/Pod/Command/RepoSq/Remove.html
+++ b/doc/Pod/Command/RepoSq/Remove.html
@@ -6,7 +6,7 @@
 <title>
   Class: Pod::Command::RepoSq::Remove
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -105,10 +105,10 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Subclass of <span class='object_link'><a href="../RepoSq.html" title="Pod::Command::RepoSq (class)">Pod::Command::RepoSq</a></span>
-Provides support for the <code>pod repo-sq remove</code> command, which removes
-the targeted Square SDK repository from the user’s cocoapods local
-repositories store.</p>
+
+<p>Subclass of <span class='object_link'><a href="../RepoSq.html" title="Pod::Command::RepoSq (class)">Pod::Command::RepoSq</a></span> Provides support for the <code>pod repo-sq
+remove</code> command, which removes the targeted Square SDK repository
+from the user&#39;s cocoapods local repositories store.</p>
 
 
   </div>
@@ -150,7 +150,8 @@ repositories store.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>A new instance of Remove.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>A new instance of Remove.</p>
 </div></span>
 
 </li>
@@ -173,7 +174,9 @@ repositories store.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Removes a Square SDK repository from the current user <span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Removes a Square SDK repository from the current user
+<span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
 </div></span>
 
 </li>
@@ -196,7 +199,8 @@ repositories store.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Validates that the required argument <code>NAME</code> is present.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Validates that the required argument <code>NAME</code> is present.</p>
 </div></span>
 
 </li>
@@ -231,7 +235,8 @@ repositories store.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns a new instance of Remove</p>
+
+<p>Returns a new instance of Remove</p>
 
 
   </div>
@@ -280,7 +285,8 @@ repositories store.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Removes a Square SDK repository from the current user
+
+<p>Removes a Square SDK repository from the current user
 <span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
 
 
@@ -325,7 +331,8 @@ repositories store.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Validates that the required argument <code>NAME</code> is present.</p>
+
+<p>Validates that the required argument <code>NAME</code> is present.</p>
 
 
   </div>
@@ -361,9 +368,9 @@ repositories store.</p>
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:23 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/Pod/Command/RepoSq/Update.html
+++ b/doc/Pod/Command/RepoSq/Update.html
@@ -6,7 +6,7 @@
 <title>
   Class: Pod::Command::RepoSq::Update
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -105,10 +105,10 @@
 
 <h2>Overview</h2><div class="docstring">
   <div class="discussion">
-    <p>Subclass of <span class='object_link'><a href="../RepoSq.html" title="Pod::Command::RepoSq (class)">Pod::Command::RepoSq</a></span>
-Provides support for the <code>pod repo-sq remove</code> command, which updates
-the targeted Square SDK repository on the user’s cocoapods local
-repositories store.</p>
+
+<p>Subclass of <span class='object_link'><a href="../RepoSq.html" title="Pod::Command::RepoSq (class)">Pod::Command::RepoSq</a></span> Provides support for the <code>pod repo-sq
+remove</code> command, which updates the targeted Square SDK repository on
+the user&#39;s cocoapods local repositories store.</p>
 
 
   </div>
@@ -150,7 +150,8 @@ repositories store.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>A new instance of Update.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>A new instance of Update.</p>
 </div></span>
 
 </li>
@@ -173,7 +174,9 @@ repositories store.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Updates the podspecs of Square SDK repository on the current user <span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Updates the podspecs of Square SDK repository on the current user
+<span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
 </div></span>
 
 </li>
@@ -196,7 +199,8 @@ repositories store.</p>
 
 
 
-    <span class="summary_desc"><div class='inline'><p>Validates that the required argument <code>NAME</code> is present.</p>
+    <span class="summary_desc"><div class='inline'>
+<p>Validates that the required argument <code>NAME</code> is present.</p>
 </div></span>
 
 </li>
@@ -231,7 +235,8 @@ repositories store.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Returns a new instance of Update</p>
+
+<p>Returns a new instance of Update</p>
 
 
   </div>
@@ -280,7 +285,8 @@ repositories store.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Updates the podspecs of Square SDK repository on the current user
+
+<p>Updates the podspecs of Square SDK repository on the current user
 <span class='object_link'><a href="../../../CocoapodsRepoSq/RepositoryStore.html" title="CocoapodsRepoSq::RepositoryStore (class)">CocoapodsRepoSq::RepositoryStore</a></span>.</p>
 
 
@@ -327,7 +333,8 @@ repositories store.</p>
 
 </h3><div class="docstring">
   <div class="discussion">
-    <p>Validates that the required argument <code>NAME</code> is present.</p>
+
+<p>Validates that the required argument <code>NAME</code> is present.</p>
 
 
   </div>
@@ -363,9 +370,9 @@ repositories store.</p>
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:23 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/_index.html
+++ b/doc/_index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>
-  Documentation by YARD 0.9.9
+  Documentation by YARD 0.9.12
 
 </title>
 
@@ -52,7 +52,7 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><h1 class="noborder title">Documentation by YARD 0.9.9</h1>
+      <div id="content"><h1 class="noborder title">Documentation by YARD 0.9.12</h1>
 <div id="listing">
   <h1 class="alphaindex">Alphabetic Index</h1>
 
@@ -246,9 +246,9 @@
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:22 2018 by
+  Generated on Fri Jun  1 09:24:32 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/css/style.css
+++ b/doc/css/style.css
@@ -484,6 +484,13 @@ pre.code .rubyid_backref,
 pre.code .rubyid_nth_ref { color: #6D79DE; }
 pre.code .regexp, .dregexp { color: #036A07; }
 pre.code a { border-bottom: 1px dotted #bbf; }
+/* inline code */
+p > code {
+	padding: 1px 3px 1px 3px;
+	border: 1px solid #E1E1E8;
+	background: #F7F7F9;
+	border-radius: 4px;
+}
 
 /* Color fix for links */
 #content .summary_desc pre.code .id > .object_link a, /* identifier */

--- a/doc/file.README.html
+++ b/doc/file.README.html
@@ -6,7 +6,7 @@
 <title>
   File: README
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -57,82 +57,88 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><div id='filecontents'><h1 id="cocoapodsreposq">CocoapodsRepoSq</h1>
-<p><a href="http://rubygems.org/gems/cocoapods-repo-sq"><img src="https://badge.fury.io/rb/cocoapods-repo-sq.svg" alt="Gem Version" /></a>
-<a href="https://travis-ci.org/square/cocoapods-repo-sq"><img src="https://travis-ci.org/square/cocoapods-repo-sq.svg?branch=master" alt="Build Status" /></a>
-<a href="https://github.com/square/cocoapods-repo-sq/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-Apache2-blue.svg" alt="Apache 2 licensed" /></a></p>
+      <div id="content"><div id='filecontents'>
+<h1 id="label-CocoapodsRepoSq">CocoapodsRepoSq</h1>
+
+<p><a href="http://rubygems.org/gems/cocoapods-repo-sq"><img
+src="https://badge.fury.io/rb/cocoapods-repo-sq.svg"></a> <a
+href="https://travis-ci.org/square/cocoapods-repo-sq"><img
+src="https://travis-ci.org/square/cocoapods-repo-sq.svg?branch=master"></a>
+<a
+href="https://github.com/square/cocoapods-repo-sq/blob/master/LICENSE"><img
+src="https://img.shields.io/badge/license-Apache2-blue.svg"></a></p>
 
 <p>Adds support for Square SDK Repositories to Cocoapods</p>
 
-<h2 id="installation">Installation</h2>
+<h2 id="label-Installation">Installation</h2>
 
-<pre class="code ruby"><code class="ruby">$ gem install cocoapods-repo-sq
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ gem install cocoapods-repo-sq</code></pre>
 
-<h2 id="usage">Usage</h2>
+<h2 id="label-Usage">Usage</h2>
 
-<h3 id="integrate-in-your-project">Integrate in your project</h3>
+<h3 id="label-Integrate+in+your+project">Integrate in your project</h3>
 
-<p>Add a Square SDK Repository to your local cocoapods registry. <code>NAME</code> is a nickname you’ll use to refer to this repository later in your <code>Podfile</code> and other <code>pod repo-sq</code> commands:
-<code>shell
-$ pod repo-sq add NAME USERNAME PASSWORD
-</code></p>
+<p>Add a Square SDK Repository to your local cocoapods registry.
+<code>NAME</code> is a nickname you&#39;ll use to refer to this repository
+later in your <code>Podfile</code> and other <code>pod repo-sq</code>
+commands: <code>shell $ pod repo-sq add NAME USERNAME PASSWORD </code></p>
 
-<p>Specify your Square SDK repository in your <code>Podfile</code>:
-```ruby
-plugin ‘cocoapods-repo-sq’, :repository =&gt; ‘NAME’</p>
+<p>Specify your Square SDK repository in your <code>Podfile</code>: “`ruby
+plugin &#39;cocoapods-repo-sq&#39;, :repository =&gt; &#39;NAME&#39;</p>
 
-<p>target ‘MyTarget’ do
-  pod ‘SquareSDK’
-end
-```</p>
+<p>target &#39;MyTarget&#39; do  pod &#39;SquareSDK&#39; end “`</p>
 
-<h3 id="commands">Commands</h3>
+<h3 id="label-Commands">Commands</h3>
 
 <p>Add</p>
 
-<pre class="code ruby"><code class="ruby">$ pod repo-sq add NAME USERNAME PASSWORD
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ pod repo-sq add NAME USERNAME PASSWORD</code></pre>
 
 <p>List</p>
 
-<pre class="code ruby"><code class="ruby">$ pod repo-sq list
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ pod repo-sq list</code></pre>
 
 <p>Update</p>
 
-<pre class="code ruby"><code class="ruby">$ pod repo-sq update NAME
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ pod repo-sq update NAME</code></pre>
 
 <p>Remove</p>
 
-<pre class="code ruby"><code class="ruby">$ pod repo-sq remove NAME
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ pod repo-sq remove NAME</code></pre>
 
-<h2 id="multiple-applications">Multiple Applications</h2>
+<h2 id="label-Multiple+Applications">Multiple Applications</h2>
 
-<p>If you have multiple Square Applications you will have multiple SDK Repositories. <code>cocoapods-repo-sq</code> supports this by allowing you to add multiple repositories to your registry. Just remember to point your <code>Podfile</code> to the right one using the <code>plugin 'cocoapods-repo-sq', :repository =&gt; 'NAME'</code> statement.</p>
+<p>If you have multiple Square Applications you will have multiple SDK
+Repositories. <code>cocoapods-repo-sq</code> supports this by allowing you
+to add multiple repositories to your registry. Just remember to point your
+<code>Podfile</code> to the right one using the <code>plugin
+&#39;cocoapods-repo-sq&#39;, :repository =&gt; &#39;NAME&#39;</code>
+statement.</p>
 
-<h2 id="contributing">Contributing</h2>
+<h2 id="label-Contributing">Contributing</h2>
 
-<p>We are currently not accepting code contributions to this repository. If you found a bug or have a feature request please <a href="https://github.com/square/cocoapods-repo-sq/issues/new">Submit it here</a>.</p>
+<p>We are currently not accepting code contributions to this repository. If
+you found a bug or have a feature request please <a
+href="https://github.com/square/cocoapods-repo-sq/issues/new">Submit it
+here</a>.</p>
 
-<p>If you are curious about Cocoapods and its plugin system take a look at the following guides:
-- https://blog.cocoapods.org/CocoaPods-0.28/
-- https://guides.cocoapods.org/reference.html
-- https://github.com/CocoaPods/cocoapods-plugins</p>
+<p>If you are curious about Cocoapods and its plugin system take a look at the
+following guides: - <a
+href="https://blog.cocoapods.org/CocoaPods-0.28">blog.cocoapods.org/CocoaPods-0.28</a>/
+- <a
+href="https://guides.cocoapods.org/reference.html">guides.cocoapods.org/reference.html</a>
+- <a
+href="https://github.com/CocoaPods/cocoapods-plugins">github.com/CocoaPods/cocoapods-plugins</a></p>
 
-<h2 id="building">Building</h2>
+<h2 id="label-Building">Building</h2>
 
-<pre class="code ruby"><code class="ruby">$ rake build
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ rake build</code></pre>
 
-<h2 id="testing">Testing</h2>
+<h2 id="label-Testing">Testing</h2>
 
-<pre class="code ruby"><code class="ruby">$ rake specs
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ rake specs</code></pre>
 
-<h2 id="license">License</h2>
+<h2 id="label-License">License</h2>
 
 <pre class="code ruby"><code class="ruby">Copyright 2018 Square Inc.
 
@@ -146,14 +152,13 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.
-</code></pre>
+limitations under the License.</code></pre>
 </div></div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:22 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/frames.html
+++ b/doc/frames.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-	<title>Documentation by YARD 0.9.9</title>
+	<title>Documentation by YARD 0.9.12</title>
 </head>
 <script type="text/javascript" charset="utf-8">
   var match = unescape(window.location.hash).match(/^#!(.+)/);

--- a/doc/index.html
+++ b/doc/index.html
@@ -6,7 +6,7 @@
 <title>
   File: README
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -57,82 +57,88 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><div id='filecontents'><h1 id="cocoapodsreposq">CocoapodsRepoSq</h1>
-<p><a href="http://rubygems.org/gems/cocoapods-repo-sq"><img src="https://badge.fury.io/rb/cocoapods-repo-sq.svg" alt="Gem Version" /></a>
-<a href="https://travis-ci.org/square/cocoapods-repo-sq"><img src="https://travis-ci.org/square/cocoapods-repo-sq.svg?branch=master" alt="Build Status" /></a>
-<a href="https://github.com/square/cocoapods-repo-sq/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-Apache2-blue.svg" alt="Apache 2 licensed" /></a></p>
+      <div id="content"><div id='filecontents'>
+<h1 id="label-CocoapodsRepoSq">CocoapodsRepoSq</h1>
+
+<p><a href="http://rubygems.org/gems/cocoapods-repo-sq"><img
+src="https://badge.fury.io/rb/cocoapods-repo-sq.svg"></a> <a
+href="https://travis-ci.org/square/cocoapods-repo-sq"><img
+src="https://travis-ci.org/square/cocoapods-repo-sq.svg?branch=master"></a>
+<a
+href="https://github.com/square/cocoapods-repo-sq/blob/master/LICENSE"><img
+src="https://img.shields.io/badge/license-Apache2-blue.svg"></a></p>
 
 <p>Adds support for Square SDK Repositories to Cocoapods</p>
 
-<h2 id="installation">Installation</h2>
+<h2 id="label-Installation">Installation</h2>
 
-<pre class="code ruby"><code class="ruby">$ gem install cocoapods-repo-sq
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ gem install cocoapods-repo-sq</code></pre>
 
-<h2 id="usage">Usage</h2>
+<h2 id="label-Usage">Usage</h2>
 
-<h3 id="integrate-in-your-project">Integrate in your project</h3>
+<h3 id="label-Integrate+in+your+project">Integrate in your project</h3>
 
-<p>Add a Square SDK Repository to your local cocoapods registry. <code>NAME</code> is a nickname you’ll use to refer to this repository later in your <code>Podfile</code> and other <code>pod repo-sq</code> commands:
-<code>shell
-$ pod repo-sq add NAME USERNAME PASSWORD
-</code></p>
+<p>Add a Square SDK Repository to your local cocoapods registry.
+<code>NAME</code> is a nickname you&#39;ll use to refer to this repository
+later in your <code>Podfile</code> and other <code>pod repo-sq</code>
+commands: <code>shell $ pod repo-sq add NAME USERNAME PASSWORD </code></p>
 
-<p>Specify your Square SDK repository in your <code>Podfile</code>:
-```ruby
-plugin ‘cocoapods-repo-sq’, :repository =&gt; ‘NAME’</p>
+<p>Specify your Square SDK repository in your <code>Podfile</code>: “`ruby
+plugin &#39;cocoapods-repo-sq&#39;, :repository =&gt; &#39;NAME&#39;</p>
 
-<p>target ‘MyTarget’ do
-  pod ‘SquareSDK’
-end
-```</p>
+<p>target &#39;MyTarget&#39; do  pod &#39;SquareSDK&#39; end “`</p>
 
-<h3 id="commands">Commands</h3>
+<h3 id="label-Commands">Commands</h3>
 
 <p>Add</p>
 
-<pre class="code ruby"><code class="ruby">$ pod repo-sq add NAME USERNAME PASSWORD
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ pod repo-sq add NAME USERNAME PASSWORD</code></pre>
 
 <p>List</p>
 
-<pre class="code ruby"><code class="ruby">$ pod repo-sq list
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ pod repo-sq list</code></pre>
 
 <p>Update</p>
 
-<pre class="code ruby"><code class="ruby">$ pod repo-sq update NAME
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ pod repo-sq update NAME</code></pre>
 
 <p>Remove</p>
 
-<pre class="code ruby"><code class="ruby">$ pod repo-sq remove NAME
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ pod repo-sq remove NAME</code></pre>
 
-<h2 id="multiple-applications">Multiple Applications</h2>
+<h2 id="label-Multiple+Applications">Multiple Applications</h2>
 
-<p>If you have multiple Square Applications you will have multiple SDK Repositories. <code>cocoapods-repo-sq</code> supports this by allowing you to add multiple repositories to your registry. Just remember to point your <code>Podfile</code> to the right one using the <code>plugin 'cocoapods-repo-sq', :repository =&gt; 'NAME'</code> statement.</p>
+<p>If you have multiple Square Applications you will have multiple SDK
+Repositories. <code>cocoapods-repo-sq</code> supports this by allowing you
+to add multiple repositories to your registry. Just remember to point your
+<code>Podfile</code> to the right one using the <code>plugin
+&#39;cocoapods-repo-sq&#39;, :repository =&gt; &#39;NAME&#39;</code>
+statement.</p>
 
-<h2 id="contributing">Contributing</h2>
+<h2 id="label-Contributing">Contributing</h2>
 
-<p>We are currently not accepting code contributions to this repository. If you found a bug or have a feature request please <a href="https://github.com/square/cocoapods-repo-sq/issues/new">Submit it here</a>.</p>
+<p>We are currently not accepting code contributions to this repository. If
+you found a bug or have a feature request please <a
+href="https://github.com/square/cocoapods-repo-sq/issues/new">Submit it
+here</a>.</p>
 
-<p>If you are curious about Cocoapods and its plugin system take a look at the following guides:
-- https://blog.cocoapods.org/CocoaPods-0.28/
-- https://guides.cocoapods.org/reference.html
-- https://github.com/CocoaPods/cocoapods-plugins</p>
+<p>If you are curious about Cocoapods and its plugin system take a look at the
+following guides: - <a
+href="https://blog.cocoapods.org/CocoaPods-0.28">blog.cocoapods.org/CocoaPods-0.28</a>/
+- <a
+href="https://guides.cocoapods.org/reference.html">guides.cocoapods.org/reference.html</a>
+- <a
+href="https://github.com/CocoaPods/cocoapods-plugins">github.com/CocoaPods/cocoapods-plugins</a></p>
 
-<h2 id="building">Building</h2>
+<h2 id="label-Building">Building</h2>
 
-<pre class="code ruby"><code class="ruby">$ rake build
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ rake build</code></pre>
 
-<h2 id="testing">Testing</h2>
+<h2 id="label-Testing">Testing</h2>
 
-<pre class="code ruby"><code class="ruby">$ rake specs
-</code></pre>
+<pre class="code ruby"><code class="ruby">$ rake specs</code></pre>
 
-<h2 id="license">License</h2>
+<h2 id="label-License">License</h2>
 
 <pre class="code ruby"><code class="ruby">Copyright 2018 Square Inc.
 
@@ -146,14 +152,13 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.
-</code></pre>
+limitations under the License.</code></pre>
 </div></div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:22 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/doc/top-level-namespace.html
+++ b/doc/top-level-namespace.html
@@ -6,7 +6,7 @@
 <title>
   Top Level Namespace
 
-    &mdash; Documentation by YARD 0.9.9
+    &mdash; Documentation by YARD 0.9.12
 
 </title>
 
@@ -100,9 +100,9 @@
 </div>
 
       <div id="footer">
-  Generated on Tue May  8 15:22:22 2018 by
+  Generated on Fri Jun  1 09:24:33 2018 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.9 (ruby-2.4.2).
+  0.9.12 (ruby-2.4.0).
 </div>
 
     </div>

--- a/lib/cocoapods_repo_sq.rb
+++ b/lib/cocoapods_repo_sq.rb
@@ -22,5 +22,5 @@
 # Main namespace for cocoapods-repo-sq plugin
 module CocoapodsRepoSq
   # Plugin version
-  VERSION = '0.0.1'.freeze
+  VERSION = '0.0.2'.freeze
 end

--- a/lib/cocoapods_repo_sq/repository.rb
+++ b/lib/cocoapods_repo_sq/repository.rb
@@ -93,8 +93,9 @@ module CocoapodsRepoSq
 
       # perform cleanup
       specs_path = File.join(@path, 'Specs')
-      FileUtils.rm(File.join(new_specs_path, "file.zip"))
-      FileUtils.rm_rf(specs_path)
+      new_specs_file = File.join(new_specs_path, "file.zip")
+      FileUtils.rm(new_specs_file) if File.exists?(new_specs_file)
+      FileUtils.rm_rf(specs_path) if Dir.exists?(specs_path)
       FileUtils.mv(new_specs_path, specs_path)
       nil
     end
@@ -102,7 +103,7 @@ module CocoapodsRepoSq
     private
     def get_temporary_path
       temp_path = File.join(@path, 'Specs.new')
-      FileUtils.rm_rf(temp_path)
+      FileUtils.rm_rf(temp_path) if Dir.exists?(temp_path)
       temp_path
     end
   end

--- a/spec/unit/cocoapods_repo_sq/repository_spec.rb
+++ b/spec/unit/cocoapods_repo_sq/repository_spec.rb
@@ -46,9 +46,16 @@ module CocoapodsRepoSq
       specs_path = File.join(@path, 'Specs')
       CocoapodsRepoSq::Downloader.expects(:new).with(new_specs_path, "specs.zip", :repository => @repository).returns(downloader)
 
+      Dir.expects(:exists?).with(new_specs_path).returns(true)
       FileUtils.expects(:rm_rf).with(new_specs_path)
-      FileUtils.expects(:rm).with(File.join(new_specs_path, "file.zip"))
+
+      new_specs_file = File.join(new_specs_path, "file.zip")
+      File.expects(:exists?).with(new_specs_file).returns(true)
+      FileUtils.expects(:rm).with(new_specs_file)
+
+      Dir.expects(:exists?).with(specs_path).returns(true)
       FileUtils.expects(:rm_rf).with(specs_path)
+
       FileUtils.expects(:mv).with(new_specs_path, specs_path)
 
       @repository.update_specs


### PR DESCRIPTION
For some users the `unzip` command used by Cocoapods removes the zip file after being extracted causing a failure when our gem tried to download it as well. I am adding checks for file and directory existence before trying to delete them. 

The important changes are on the first commit "https://github.com/square/cocoapods-repo-sq/commit/4025c6de90c0a716f27685e07dcff2bb8ddd8496". The second one bumps the version to `0.0.2` and updates the docs generated with YARN